### PR TITLE
保存ディレクトリをarticleに変更

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  def self.carrierwave_store_id
+    to_s.underscore
+  end
 end

--- a/app/models/form/article.rb
+++ b/app/models/form/article.rb
@@ -1,2 +1,5 @@
 class Form::Article < ::Article
+  def self.carrierwave_store_id
+    'article'
+  end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -10,7 +10,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "uploads/#{model.class.carrierwave_store_id}/#{mounted_as}/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:


### PR DESCRIPTION
フォームオブジェクトでファイルのアップロードをすると、保存ディレクトリがフォームオブジェクトのクラス名をベースにしたものになってしまいます。

そこでImageUploaderのクラス名をベースにしている部分を、ApplicationRecordに移し、フォームオブジェクトでは対象のモデル名を返すようにオーバーライドして対応します。